### PR TITLE
feat: add auth gate with Supabase session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import Dashboard from './components/Dashboard'
+import AuthGate from './components/AuthGate'
 import GoodTimeJournal from './components/GoodTimeJournal'
 import Prototypes from './components/Prototypes'
 import FailureReframe from './components/FailureReframe'
@@ -23,7 +24,14 @@ export default function App() {
       </nav>
       <div className="p-4">
         <Routes>
-          <Route path="/" element={<Dashboard />} />
+          <Route
+            path="/"
+            element={
+              <AuthGate>
+                <Dashboard />
+              </AuthGate>
+            }
+          />
           <Route path="/gtj" element={<GoodTimeJournal />} />
           <Route path="/prototypes" element={<Prototypes />} />
           <Route path="/failure" element={<FailureReframe />} />

--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState, ReactNode } from 'react'
+import { Session } from '@supabase/supabase-js'
+import { supabase } from '../supabaseClient'
+import Login from './Login'
+
+interface Props {
+  children: ReactNode
+}
+
+export default function AuthGate({ children }: Props) {
+  const [session, setSession] = useState<Session | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session))
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  if (!session) {
+    return <Login />
+  }
+
+  return <>{children}</>
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,7 +24,19 @@ export default function Dashboard() {
   }
 
   useEffect(() => {
-    if (userId) loadMetrics()
+    if (!userId) return
+    const init = async () => {
+      const { data } = await supabase
+        .from('life_meters')
+        .select('user_id')
+        .eq('user_id', userId)
+        .maybeSingle()
+      if (!data) {
+        await supabase.from('life_meters').upsert({ user_id: userId })
+      }
+      loadMetrics()
+    }
+    init()
   }, [userId])
 
   const updateMetric = async (label: string, value: number) => {

--- a/src/components/Habits.tsx
+++ b/src/components/Habits.tsx
@@ -57,7 +57,7 @@ export default function Habits() {
       <ul className="space-y-2">
         {habits.map(h => (
           <li key={h.id} className="border p-2">
-            Después de {h.trigger} -> haré {h.action}
+            Después de {h.trigger} {'->'} haré {h.action}
           </li>
         ))}
       </ul>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add AuthGate component to show login when no session
- initialize life_meters row for signed-in users
- fix habits list rendering and add TS vite env types

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a512a06ee88321b9e39ee6001827e2