### PR TITLE
feat: enhance GTJ with scoring and filters

### DIFF
--- a/src/components/GoodTimeJournal.tsx
+++ b/src/components/GoodTimeJournal.tsx
@@ -1,32 +1,51 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../supabaseClient'
+import { formatDateInput, isValidScore } from '../utils/gtj'
 
 interface Entry {
   id: number
   user_id: string
-  date: string
   activity: string
+  note: string | null
   energy: number
-  engagement: number
+  focus: number
+  satisfaction: number
+  occurred_at: string
 }
 
 export default function GoodTimeJournal() {
   const [userId, setUserId] = useState('')
   const [entries, setEntries] = useState<Entry[]>([])
   const [activity, setActivity] = useState('')
-  const [energy, setEnergy] = useState(5)
-  const [engagement, setEngagement] = useState(5)
+  const [energy, setEnergy] = useState(3)
+  const [focus, setFocus] = useState(3)
+  const [satisfaction, setSatisfaction] = useState(3)
+  const [note, setNote] = useState('')
+  const [occurredAt, setOccurredAt] = useState(formatDateInput(new Date()))
+
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [minScore, setMinScore] = useState(1)
+  const [maxScore, setMaxScore] = useState(5)
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => setUserId(data.user?.id ?? ''))
   }, [])
 
   const load = async () => {
-    const { data } = await supabase
+    setLoading(true)
+    setError('')
+    const { data, error } = await supabase
       .from('gtj_entries')
       .select('*')
-      .order('date', { ascending: false })
-    if (data) setEntries(data)
+      .eq('user_id', userId)
+      .order('occurred_at', { ascending: false })
+    if (error) setError(error.message)
+    if (data) setEntries(data as Entry[])
+    setLoading(false)
   }
 
   useEffect(() => {
@@ -35,18 +54,40 @@ export default function GoodTimeJournal() {
 
   const addEntry = async (e: React.FormEvent) => {
     e.preventDefault()
-    await supabase.from('gtj_entries').insert({
+    if (![energy, focus, satisfaction].every(isValidScore)) {
+      setError('Puntajes inválidos')
+      return
+    }
+    setError('')
+    const { error } = await supabase.from('gtj_entries').insert({
       user_id: userId,
-      date: new Date().toISOString(),
       activity,
       energy,
-      engagement,
+      focus,
+      satisfaction,
+      note: note || null,
+      occurred_at: new Date(occurredAt).toISOString(),
     })
+    if (error) {
+      setError(error.message)
+      return
+    }
     setActivity('')
-    setEnergy(5)
-    setEngagement(5)
+    setEnergy(3)
+    setFocus(3)
+    setSatisfaction(3)
+    setNote('')
+    setOccurredAt(formatDateInput(new Date()))
     load()
   }
+
+  const filtered = entries.filter(e => {
+    const d = e.occurred_at.slice(0, 10)
+    if (startDate && d < startDate) return false
+    if (endDate && d > endDate) return false
+    const scores = [e.energy, e.focus, e.satisfaction]
+    return scores.every(s => s >= minScore && s <= maxScore)
+  })
 
   return (
     <div>
@@ -56,37 +97,111 @@ export default function GoodTimeJournal() {
           value={activity}
           onChange={e => setActivity(e.target.value)}
           placeholder="Actividad"
+          required
         />
-        <div className="flex gap-2">
-          <label>Energía {energy}</label>
-          <input
-            type="range"
-            min="1"
-            max="10"
+        <div className="flex gap-2 flex-wrap">
+          <label>Energía</label>
+          <select
+            className="border p-1"
             value={energy}
             onChange={e => setEnergy(Number(e.target.value))}
-          />
+          >
+            {[1, 2, 3, 4, 5].map(n => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+          <label>Enfoque</label>
+          <select
+            className="border p-1"
+            value={focus}
+            onChange={e => setFocus(Number(e.target.value))}
+          >
+            {[1, 2, 3, 4, 5].map(n => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+          <label>Satisfacción</label>
+          <select
+            className="border p-1"
+            value={satisfaction}
+            onChange={e => setSatisfaction(Number(e.target.value))}
+          >
+            {[1, 2, 3, 4, 5].map(n => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
         </div>
-        <div className="flex gap-2">
-          <label>Engagement {engagement}</label>
-          <input
-            type="range"
-            min="1"
-            max="10"
-            value={engagement}
-            onChange={e => setEngagement(Number(e.target.value))}
-          />
-        </div>
+        <textarea
+          className="border p-2 w-full"
+          value={note}
+          onChange={e => setNote(e.target.value)}
+          placeholder="Nota (opcional)"
+        />
+        <input
+          type="date"
+          className="border p-2 w-full"
+          value={occurredAt}
+          onChange={e => setOccurredAt(e.target.value)}
+        />
         <button className="bg-green-500 text-white px-4 py-2" type="submit">
           Agregar
         </button>
       </form>
+
+      <div className="mb-4 space-y-2">
+        <div className="flex gap-2">
+          <input
+            type="date"
+            className="border p-2"
+            value={startDate}
+            onChange={e => setStartDate(e.target.value)}
+          />
+          <input
+            type="date"
+            className="border p-2"
+            value={endDate}
+            onChange={e => setEndDate(e.target.value)}
+          />
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            min={1}
+            max={5}
+            className="border p-2 w-20"
+            value={minScore}
+            onChange={e => setMinScore(Number(e.target.value))}
+          />
+          <input
+            type="number"
+            min={1}
+            max={5}
+            className="border p-2 w-20"
+            value={maxScore}
+            onChange={e => setMaxScore(Number(e.target.value))}
+          />
+        </div>
+      </div>
+
+      {loading && <div>Cargando...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {!loading && filtered.length === 0 && !error && <div>No hay entradas</div>}
+
       <ul className="space-y-2">
-        {entries.map(e => (
+        {filtered.map(e => (
           <li key={e.id} className="border p-2">
-            <div>{new Date(e.date).toLocaleString()}</div>
+            <div>{new Date(e.occurred_at).toLocaleDateString()}</div>
             <div>{e.activity}</div>
-            <div>Energía: {e.energy} / Engagement: {e.engagement}</div>
+            {e.note && <div className="italic">{e.note}</div>}
+            <div>
+              Energía: {e.energy} / Enfoque: {e.focus} / Satisfacción: {e.satisfaction}
+            </div>
           </li>
         ))}
       </ul>

--- a/src/utils/gtj.d.ts
+++ b/src/utils/gtj.d.ts
@@ -1,0 +1,2 @@
+export function formatDateInput(date: Date): string
+export function isValidScore(n: number): boolean

--- a/src/utils/gtj.js
+++ b/src/utils/gtj.js
@@ -1,0 +1,7 @@
+export function formatDateInput(date) {
+  return date.toISOString().split('T')[0]
+}
+
+export function isValidScore(n) {
+  return Number.isInteger(n) && n >= 1 && n <= 5
+}

--- a/src/utils/gtj.test.js
+++ b/src/utils/gtj.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { formatDateInput, isValidScore } from './gtj.js'
+
+test('formatDateInput returns YYYY-MM-DD', () => {
+  const d = new Date('2024-05-15T10:00:00Z')
+  assert.equal(formatDateInput(d), '2024-05-15')
+})
+
+test('isValidScore validates 1-5 range', () => {
+  assert.ok(isValidScore(1))
+  assert.ok(isValidScore(5))
+  assert.ok(!isValidScore(0))
+  assert.ok(!isValidScore(6))
+  assert.ok(!isValidScore(3.5))
+})


### PR DESCRIPTION
## Summary
- Expand Good Time Journal entries with energy/focus/satisfaction (1-5), optional notes and date
- Add list filters for date and score range with loading, empty and error states
- Provide date formatting and score validation helpers with basic tests

## Testing
- `npx tsc --noEmit`
- `node --test src/utils/gtj.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a515d79e8c832198eaa7a6e4d136f9