### PR TITLE
Add failure reframe CRUD page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
         <Link to="/">Dashboard</Link>
         <Link to="/gtj">GTJ</Link>
         <Link to="/prototypes">Prototipos</Link>
-        <Link to="/failure">Failure Reframe</Link>
+        <Link to="/failure-reframe">Failure Reframe</Link>
         <Link to="/odyssey">Odyssey</Link>
         <Link to="/habits">Hábitos</Link>
         <Link to="/weekly">Revisión semanal</Link>
@@ -34,7 +34,7 @@ export default function App() {
           />
           <Route path="/gtj" element={<GoodTimeJournal />} />
           <Route path="/prototypes" element={<Prototypes />} />
-          <Route path="/failure" element={<FailureReframe />} />
+          <Route path="/failure-reframe" element={<FailureReframe />} />
           <Route path="/odyssey" element={<Odyssey />} />
           <Route path="/habits" element={<Habits />} />
           <Route path="/weekly" element={<WeeklyReview />} />

--- a/src/components/FailureReframe.tsx
+++ b/src/components/FailureReframe.tsx
@@ -1,67 +1,239 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { supabase } from '../supabaseClient'
 
-interface Item {
+interface FailureReframeItem {
   id: number
-  user_id: string
-  failure: string
-  lesson: string
+  event: string
+  assumption: string | null
+  learning: string | null
+  adjustment: string | null
+  next_prototype_date: string | null
+  created_at: string
 }
 
 export default function FailureReframe() {
   const [userId, setUserId] = useState('')
-  const [items, setItems] = useState<Item[]>([])
-  const [failure, setFailure] = useState('')
-  const [lesson, setLesson] = useState('')
+  const [items, setItems] = useState<FailureReframeItem[]>([])
+  const [editingId, setEditingId] = useState<number | null>(null)
+
+  const [event, setEvent] = useState('')
+  const [assumption, setAssumption] = useState('')
+  const [learning, setLearning] = useState('')
+  const [adjustment, setAdjustment] = useState('')
+  const [nextDate, setNextDate] = useState('')
+
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  const eventRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => setUserId(data.user?.id ?? ''))
   }, [])
 
   const load = async () => {
-    const { data } = await supabase.from('failure_reframes').select('*')
-    if (data) setItems(data)
+    const { data, error } = await supabase
+      .from('failure_reframes')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+    if (error) {
+      setError('Error al cargar')
+    } else if (data) {
+      setItems(data)
+    }
   }
 
   useEffect(() => {
     if (userId) load()
   }, [userId])
 
-  const add = async (e: React.FormEvent) => {
+  const resetForm = () => {
+    setEditingId(null)
+    setEvent('')
+    setAssumption('')
+    setLearning('')
+    setAdjustment('')
+    setNextDate('')
+    setError('')
+    eventRef.current?.focus()
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await supabase.from('failure_reframes').insert({ user_id: userId, failure, lesson })
-    setFailure('')
-    setLesson('')
-    load()
+    setError('')
+    setMessage('')
+    if (!event.trim()) {
+      setError('El evento es requerido')
+      eventRef.current?.focus()
+      return
+    }
+    const payload = {
+      event,
+      assumption: assumption || null,
+      learning: learning || null,
+      adjustment: adjustment || null,
+      next_prototype_date: nextDate || null,
+    }
+    let resp
+    if (editingId) {
+      resp = await supabase.from('failure_reframes').update(payload).eq('id', editingId)
+    } else {
+      resp = await supabase
+        .from('failure_reframes')
+        .insert({ user_id: userId, ...payload })
+    }
+    if (resp.error) {
+      setError('Error al guardar')
+    } else {
+      setMessage('Guardado con éxito')
+      resetForm()
+      load()
+    }
+  }
+
+  const edit = (item: FailureReframeItem) => {
+    setEditingId(item.id)
+    setEvent(item.event)
+    setAssumption(item.assumption ?? '')
+    setLearning(item.learning ?? '')
+    setAdjustment(item.adjustment ?? '')
+    setNextDate(item.next_prototype_date ?? '')
+    setMessage('')
+    setError('')
+    eventRef.current?.focus()
+  }
+
+  const remove = async (id: number) => {
+    const { error } = await supabase.from('failure_reframes').delete().eq('id', id)
+    if (error) {
+      setError('Error al eliminar')
+    } else {
+      setMessage('Eliminado')
+      if (editingId === id) resetForm()
+      load()
+    }
   }
 
   return (
     <div>
-      <form onSubmit={add} className="space-y-2 mb-4">
-        <input
-          className="border p-2 w-full"
-          value={failure}
-          onChange={e => setFailure(e.target.value)}
-          placeholder="Fallo"
-        />
-        <input
-          className="border p-2 w-full"
-          value={lesson}
-          onChange={e => setLesson(e.target.value)}
-          placeholder="Aprendizaje"
-        />
-        <button className="bg-purple-500 text-white px-4 py-2" type="submit">
-          Agregar
-        </button>
+      {message && (
+        <div role="status" className="p-2 mb-2 text-green-700">
+          {message}
+        </div>
+      )}
+      {error && (
+        <div role="alert" className="p-2 mb-2 text-red-700">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-2 mb-4">
+        <div>
+          <label htmlFor="event" className="block">
+            Evento
+          </label>
+          <input
+            id="event"
+            ref={eventRef}
+            className="border p-2 w-full"
+            value={event}
+            onChange={e => setEvent(e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div>
+          <label htmlFor="assumption" className="block">
+            Suposición
+          </label>
+          <input
+            id="assumption"
+            className="border p-2 w-full"
+            value={assumption}
+            onChange={e => setAssumption(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="learning" className="block">
+            Aprendizaje
+          </label>
+          <input
+            id="learning"
+            className="border p-2 w-full"
+            value={learning}
+            onChange={e => setLearning(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="adjustment" className="block">
+            Ajuste
+          </label>
+          <input
+            id="adjustment"
+            className="border p-2 w-full"
+            value={adjustment}
+            onChange={e => setAdjustment(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="nextDate" className="block">
+            Próximo prototipo
+          </label>
+          <input
+            id="nextDate"
+            type="date"
+            className="border p-2 w-full"
+            value={nextDate}
+            onChange={e => setNextDate(e.target.value)}
+          />
+        </div>
+        <div className="flex gap-2">
+          <button className="bg-purple-500 text-white px-4 py-2" type="submit">
+            {editingId ? 'Actualizar' : 'Agregar'}
+          </button>
+          {editingId && (
+            <button
+              type="button"
+              className="px-4 py-2 border"
+              onClick={resetForm}
+            >
+              Cancelar
+            </button>
+          )}
+        </div>
       </form>
-      <ul className="space-y-2">
-        {items.map(i => (
-          <li key={i.id} className="border p-2">
-            <div className="font-bold">{i.failure}</div>
-            <div>{i.lesson}</div>
-          </li>
-        ))}
-      </ul>
+
+      {items.length === 0 ? (
+        <p>No hay reframes aún.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map(i => (
+            <li key={i.id} className="border p-2">
+              <div className="font-bold">{i.event}</div>
+              {i.assumption && <div>Suposición: {i.assumption}</div>}
+              {i.learning && <div>Aprendizaje: {i.learning}</div>}
+              {i.adjustment && <div>Ajuste: {i.adjustment}</div>}
+              {i.next_prototype_date && (
+                <div>Próximo prototipo: {i.next_prototype_date}</div>
+              )}
+              <div className="mt-2 flex gap-2">
+                <button
+                  className="text-blue-600"
+                  onClick={() => edit(i)}
+                >
+                  Editar
+                </button>
+                <button
+                  className="text-red-600"
+                  onClick={() => remove(i.id)}
+                >
+                  Eliminar
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -31,8 +31,12 @@ create table if not exists prototypes (
 create table if not exists failure_reframes (
   id bigint generated always as identity primary key,
   user_id uuid not null references auth.users(id) on delete cascade,
-  failure text not null,
-  lesson text not null
+  event text not null,
+  assumption text,
+  learning text,
+  adjustment text,
+  next_prototype_date date,
+  created_at timestamptz not null default now()
 );
 
 create table if not exists odyssey_plans (


### PR DESCRIPTION
## Summary
- implement `/failure-reframe` page with Supabase CRUD, validation, and accessible form
- update navigation to link to new page
- expand Supabase schema for failure reframes with detailed fields

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52d4085588321beb3a42c2a131d4f